### PR TITLE
Add .gitignore for Flutter and Node artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Flutter
+build/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# IDEs
+*.iml
+.idea/


### PR DESCRIPTION
## Summary
- add `.gitignore` with rules for Flutter, Node, macOS, Windows and IDE artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad8f8e8d483268df41b3c0a9c31d9