### PR TITLE
Add initial Node backend skeleton

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,28 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export interface EnvConfig {
+  PORT: number;
+  MPESA_CONSUMER_KEY: string;
+  MONGO_URI: string;
+  OPENAI_API_KEY: string;
+}
+
+const required = ['PORT', 'MPESA_CONSUMER_KEY', 'MONGO_URI', 'OPENAI_API_KEY'] as const;
+
+const env: EnvConfig = {
+  PORT: parseInt(process.env.PORT || '', 10),
+  MPESA_CONSUMER_KEY: process.env.MPESA_CONSUMER_KEY || '',
+  MONGO_URI: process.env.MONGO_URI || '',
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
+};
+
+for (const key of required) {
+  const value = env[key as keyof EnvConfig];
+  if (!value && value !== 0) {
+    throw new Error(`Missing environment variable ${key}`);
+  }
+}
+
+export default env;

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from 'express';
+
+export class AuthController {
+  async login(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      // TODO: implement login logic
+      res.json({ message: 'login not implemented' });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async signup(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      // TODO: implement signup logic
+      res.json({ message: 'signup not implemented' });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  logout(req: Request, res: Response, next: NextFunction): void {
+    try {
+      // TODO: implement logout logic
+      res.json({ message: 'logout not implemented' });
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/backend/src/middleware/error.middleware.ts
+++ b/backend/src/middleware/error.middleware.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function errorHandler(
+  err: any,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  const status = err.status || 500;
+  res.status(status).json({ error: err.message });
+}

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+const router = Router();
+
+// TODO: replace placeholders with real route handlers
+router.use('/auth', Router());
+router.use('/budget', Router());
+router.use('/mpesa', Router());
+router.use('/ai', Router());
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,30 @@
+import express from 'express';
+import compression from 'compression';
+import helmet from 'helmet';
+import cors from 'cors';
+
+import env from './config/env';
+import apiRouter from './routes/api';
+import { errorHandler } from './middleware/error.middleware';
+
+const app = express();
+
+app.use(express.json());
+app.use(compression());
+app.use(helmet());
+app.use(cors());
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.use('/api', apiRouter);
+
+app.use(errorHandler);
+
+app.listen(env.PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Server listening on port ${env.PORT}`);
+});
+
+export default app;

--- a/log.md
+++ b/log.md
@@ -57,3 +57,9 @@
 - Updated README repository structure to reflect new mobile source layout
 - Marked `setup-flutter` task as complete in plan.md
 
+
+## 2025-06-15
+### Added
+- Created `backend` project folder with TypeScript Express skeleton
+- Implemented environment loader, server entry, API index router, auth controller stub, and error handler middleware
+- Marked new `setup-backend` task as complete in plan.md

--- a/plan.md
+++ b/plan.md
@@ -14,7 +14,8 @@
 
 ### Phase 1: Foundation (M1)
 - [x] `setup-flutter` - Initialize Flutter project structure
-- [ ] `ui-mockups` - Create Figma designs for core screens  
+- [x] `setup-backend` - Initialize Node.js API skeleton
+- [ ] `ui-mockups` - Create Figma designs for core screens
 - [ ] `auth-system` - Implement user registration/login
 - [ ] `expense-tracker` - Build manual expense entry interface
 - [ ] `budget-calculator` - Core budget calculation logic


### PR DESCRIPTION
## Summary
- scaffold Node.js API in `backend` with TypeScript
- implement environment configuration loader
- add Express server entry with middleware and health endpoint
- stub API router, auth controller, and error handler
- mark `setup-backend` task done in the plan and log updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b264a409c83269014e01c98310223