### PR TITLE
Add ML training and inference scaffolding

### DIFF
--- a/context.json
+++ b/context.json
@@ -1,26 +1,55 @@
 {
   "version": "0.1.0",
   "project_name": "BajetiBuddy",
-  "last_updated": "2025-06-14T00:00:00Z",
+  "last_updated": "2025-06-16T00:00:00Z",
   "modules": [
-    { "name": "AuthSystem", "status": "in_progress", "priority": "high" },
-    { "name": "ExpenseTracker", "status": "planned", "priority": "high" },
-    { "name": "BudgetCalculator", "status": "planned", "priority": "high" },
-    { "name": "MpesaIntegration", "status": "planned", "priority": "medium" },
-    { "name": "AIRecommendations", "status": "planned", "priority": "medium" },
-    { "name": "OfflineSync", "status": "planned", "priority": "low" }
+    {
+      "name": "AuthSystem",
+      "status": "in_progress",
+      "priority": "high"
+    },
+    {
+      "name": "ExpenseTracker",
+      "status": "planned",
+      "priority": "high"
+    },
+    {
+      "name": "BudgetCalculator",
+      "status": "planned",
+      "priority": "high"
+    },
+    {
+      "name": "MpesaIntegration",
+      "status": "planned",
+      "priority": "medium"
+    },
+    {
+      "name": "AIRecommendations",
+      "status": "in_progress",
+      "priority": "medium"
+    },
+    {
+      "name": "OfflineSync",
+      "status": "planned",
+      "priority": "low"
+    },
+    {
+      "name": "ModelTraining",
+      "status": "in_progress",
+      "priority": "medium"
+    }
   ],
   "interfaces": [
     {
       "endpoint": "/v1/auth/login",
-      "method": "POST", 
+      "method": "POST",
       "schema": "see plan.md",
       "status": "planned"
     },
     {
       "endpoint": "/v1/expenses/create",
       "method": "POST",
-      "schema": "see plan.md", 
+      "schema": "see plan.md",
       "status": "planned"
     },
     {
@@ -32,9 +61,14 @@
   ],
   "flags": {
     "offline_mode": true,
-    "target_platform": ["android_low_end"],
+    "target_platform": [
+      "android_low_end"
+    ],
     "currency": "KES",
-    "language_support": ["en", "sw"],
+    "language_support": [
+      "en",
+      "sw"
+    ],
     "ai_enabled": true,
     "mpesa_integration": true,
     "local_encryption": true,
@@ -69,8 +103,18 @@
         "description": "Basic budget calculation for Kenyan household",
         "input": {
           "income": 30000,
-          "expenses": [8000, 5000, 7000, 3000],
-          "categories": ["rent", "food", "transport", "utilities"]
+          "expenses": [
+            8000,
+            5000,
+            7000,
+            3000
+          ],
+          "categories": [
+            "rent",
+            "food",
+            "transport",
+            "utilities"
+          ]
         },
         "expected_output": {
           "recommended_savings": 6000,
@@ -79,7 +123,7 @@
         }
       },
       {
-        "id": "expense-categorize-001", 
+        "id": "expense-categorize-001",
         "description": "M-Pesa transaction categorization",
         "input": {
           "transaction": "MPESA Receipt ABC123 Confirmed. Ksh500.00 paid to NAIVAS SUPERMARKET",
@@ -99,7 +143,7 @@
           "monthly_income": 45000,
           "current_expenses": {
             "rent": 15000,
-            "food": 12000, 
+            "food": 12000,
             "transport": 5000,
             "utilities": 3000
           },

--- a/log.md
+++ b/log.md
@@ -63,3 +63,14 @@
 - Bumped `last_updated` timestamp in context.json
 - Noted `auth-system` task is now in progress in plan.md
 
+
+## 2025-06-16
+### Added
+- Created `ml-models` package with training, inference, and data utilities
+- Implemented `fine_tune_openai.py` for converting CSV to JSONL
+- Added OpenAI inference wrapper and stub pytest
+- Provided sample training dataset and saving helper
+### Updated
+- Marked AI-related tasks as in progress in plan.md
+- Added `ModelTraining` module and updated `AIRecommendations` status in context.json
+- Bumped `last_updated` timestamp

--- a/ml-models/data/kenyan_financial_patterns_sample.csv
+++ b/ml-models/data/kenyan_financial_patterns_sample.csv
@@ -1,0 +1,4 @@
+query,response
+"How can I reduce food expenses?","Consider bulk buying at local markets and cooking at home."
+"What percentage of income should go to savings?","Aim to save at least 20% of your monthly income."
+"Are SACCOs a good investment option?","Yes, many Kenyans use SACCOs for competitive returns and loans."

--- a/ml-models/data/save_dataset.py
+++ b/ml-models/data/save_dataset.py
@@ -1,0 +1,15 @@
+"""Utility functions for saving training datasets."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+
+def save_jsonl(data: List[Dict], path: str) -> None:
+    """Write list of dictionaries to a JSONL file."""
+    p = Path(path)
+    with p.open("w", encoding="utf-8") as f:
+        for item in data:
+            f.write(json.dumps(item) + "\n")
+    # TODO: handle append or overwrite options

--- a/ml-models/inference/local_model.py
+++ b/ml-models/inference/local_model.py
@@ -1,0 +1,18 @@
+"""Local OpenAI model inference utilities."""
+from __future__ import annotations
+
+import os
+import openai
+
+# Replace with your fine-tuned model ID or name
+MODEL_NAME = os.getenv("OPENAI_FINE_TUNED_MODEL", "ft-bajeti-buddy")
+
+
+def predict_budget_advice(prompt: str) -> str:
+    """Return budgeting advice from the fine-tuned model."""
+    response = openai.ChatCompletion.create(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    # TODO: implement caching and proper error handling
+    return response["choices"][0]["message"]["content"].strip()

--- a/ml-models/inference/test_inference.py
+++ b/ml-models/inference/test_inference.py
@@ -1,0 +1,9 @@
+import pytest
+from .local_model import predict_budget_advice
+
+
+def test_predict_returns_string():
+    result = predict_budget_advice("test")
+    assert isinstance(result, str)
+
+# TODO: expand with real prompts and validations

--- a/ml-models/training/fine_tune_openai.py
+++ b/ml-models/training/fine_tune_openai.py
@@ -1,0 +1,35 @@
+import csv
+import json
+from pathlib import Path
+import openai
+
+DATA_CSV = Path('data/kenyan_financial_patterns.csv')
+OUTPUT_JSONL = Path('data/kenyan_financial_patterns.jsonl')
+
+
+def build_fine_tuning_dataset():
+    """Load CSV and convert rows to OpenAI fine-tuning format."""
+    dataset = []
+    with DATA_CSV.open(newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            dataset.append({
+                "messages": [
+                    {"role": "user", "content": row['query']},
+                    {"role": "assistant", "content": row['response']}
+                ]
+            })
+    return dataset
+
+
+def export_jsonl(data):
+    """Write list of dictionaries to a JSONL file."""
+    with OUTPUT_JSONL.open('w', encoding='utf-8') as f:
+        for item in data:
+            f.write(json.dumps(item) + "\n")
+
+
+if __name__ == '__main__':
+    dataset = build_fine_tuning_dataset()
+    export_jsonl(dataset)
+    # TODO: call openai.FineTune.create(...) with OUTPUT_JSONL

--- a/plan.md
+++ b/plan.md
@@ -26,9 +26,10 @@
 - [ ] `expense-categorization` - ML-based expense classification
 - [ ] `bank-integration` - Connect additional Kenyan banks
 
-### Phase 3: AI Intelligence (M3)
-- [ ] `openai-integration` - Connect GPT-3.5 for advice generation
-- [ ] `context-training` - Fine-tune model on Kenyan financial patterns
+-### Phase 3: AI Intelligence (M3)
+- [ ] `openai-integration` - Connect GPT-3.5 for advice generation *(in progress)*
+- [ ] `context-training` - Fine-tune model on Kenyan financial patterns *(in progress)*
+  - [ ] `training-script` - Convert CSV dataset and initiate model fine-tuning
 - [ ] `recommendation-engine` - Personalized budget suggestions
 - [ ] `spending-insights` - AI-generated financial insights
 


### PR DESCRIPTION
## Summary
- create `ml-models` package for data, training and inference
- script `fine_tune_openai.py` prepares JSONL for OpenAI fine-tuning
- add OpenAI inference wrapper and pytest stub
- provide dataset saving helper and sample CSV
- update plan with new training task
- track AI modules in context and update project log

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b27bfa6b083268712a951c0e52d49