### PR TITLE
Add ML pipeline stubs

### DIFF
--- a/log.md
+++ b/log.md
@@ -74,3 +74,9 @@
 - Marked AI-related tasks as in progress in plan.md
 - Added `ModelTraining` module and updated `AIRecommendations` status in context.json
 - Bumped `last_updated` timestamp
+
+## 2025-06-12
+### Added
+- Created ml-models/pipeline with stub ml_pipeline.py logging pipeline steps
+### Updated
+- Added package init for inference and mocked OpenAI calls in tests

--- a/ml-models/inference/test_inference.py
+++ b/ml-models/inference/test_inference.py
@@ -1,9 +1,14 @@
+from unittest.mock import patch
+
 import pytest
+
 from .local_model import predict_budget_advice
 
 
 def test_predict_returns_string():
-    result = predict_budget_advice("test")
-    assert isinstance(result, str)
+    with patch("openai.ChatCompletion.create") as mock_create:
+        mock_create.return_value = {"choices": [{"message": {"content": "ok"}}]}
+        result = predict_budget_advice("test")
+        assert isinstance(result, str)
 
 # TODO: expand with real prompts and validations

--- a/ml-models/pipeline/ml_pipeline.py
+++ b/ml-models/pipeline/ml_pipeline.py
@@ -1,0 +1,34 @@
+"""Machine learning pipeline steps."""
+from __future__ import annotations
+
+import logging
+
+# TODO: integrate pipeline with orchestration tools like Airflow, Prefect, or DVC
+
+
+def preprocess() -> None:
+    """Preprocess raw data for training."""
+    logging.info("Starting preprocessing step")
+    # TODO: implement preprocessing logic
+    logging.info("Completed preprocessing step")
+
+
+def train() -> None:
+    """Train the model."""
+    logging.info("Starting training step")
+    # TODO: implement training logic
+    logging.info("Completed training step")
+
+
+def evaluate() -> None:
+    """Evaluate the trained model."""
+    logging.info("Starting evaluation step")
+    # TODO: implement evaluation logic
+    logging.info("Completed evaluation step")
+
+
+def deploy() -> None:
+    """Deploy the model to a production environment."""
+    logging.info("Starting deployment step")
+    # TODO: implement deployment logic
+    logging.info("Completed deployment step")


### PR DESCRIPTION
## Summary
- provide placeholder ML pipeline with logging
- patch inference tests to mock OpenAI calls
- add package init so tests import correctly
- document pipeline addition in log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b29e27b6083269824537d3ead7de4