### PR TITLE
Add CI runner for ML pipeline

### DIFF
--- a/ml-models/pipeline/ci_run.py
+++ b/ml-models/pipeline/ci_run.py
@@ -1,0 +1,23 @@
+import sys
+
+from ml_pipeline import prepare_data, train_model, evaluate_model
+
+
+def main() -> None:
+    """Execute the ML pipeline sequentially for CI."""
+    try:
+        prepare_data()
+        train_model()
+        metrics = evaluate_model()
+    except Exception as exc:  # pragma: no cover - pipeline errors are critical
+        print(f"Pipeline failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print("\nEvaluation Metrics Summary:")
+    for key, value in metrics.items():
+        print(f"{key}: {value}")
+
+
+if __name__ == "__main__":
+    main()
+    # TODO: integrate execution with GitHub Actions


### PR DESCRIPTION
## Summary
- add CI helper script for running the ML pipeline

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_684b29e727c0832684337d043ad80df8