### PR TITLE
Add deployment milestone and Batch 7 prep note

### DIFF
--- a/log.md
+++ b/log.md
@@ -74,3 +74,9 @@
 - Marked AI-related tasks as in progress in plan.md
 - Added `ModelTraining` module and updated `AIRecommendations` status in context.json
 - Bumped `last_updated` timestamp
+
+## 2025-06-12
+### Added
+- Added milestone for deployment automation and tasks for `ml-pipeline` and `versioning-utility` in plan.md
+### Notes
+- Documented Batch 7 preparation tasks for deploy configs, Docker, and CI workflows.

--- a/plan.md
+++ b/plan.md
@@ -9,6 +9,7 @@
 | M3 | AI-Powered Budget Recommendations | @tulipoaaaaa | 2025-11-15 |
 | M4 | Offline Mode & Data Sync | @tulipoaaaaa | 2025-12-31 |
 | M5 | Beta Launch & User Testing | @tulipoaaaaa | 2026-02-28 |
+| M6 | Deployment Automation & Versioning | @tulipoaaaaa | 2026-04-30 |
 
 ## Task Decomposition
 
@@ -35,9 +36,15 @@
 
 ### Phase 4: Robustness (M4)
 - [ ] `offline-core` - Ensure core features work without internet
-- [ ] `data-sync` - Bi-directional cloud synchronization  
+- [ ] `data-sync` - Bi-directional cloud synchronization
 - [ ] `performance-opt` - Optimize for low-end Android devices
 - [ ] `security-audit` - Comprehensive security review
+
+### Phase 5: Deployment Automation (M6)
+- [ ] `ml-pipeline` - Build reproducible machine learning pipeline
+- [ ] `versioning-utility` - Automate dataset and model version tracking
+
+*Note*: Batch 7 preparation will scaffold `deploy/` configs, Docker setup, CI workflows, and GitHub Actions.
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary
- add Deployment Automation & Versioning milestone
- create Phase 5 tasks for `ml-pipeline` and `versioning-utility`
- include Batch 7 preparation note about deploy configs, Docker, and CI workflows
- log the milestone and tasks in `log.md`

## Testing
- `pytest -q` *(fails: ImportError attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_684b29f671b88326bba333256cd82456