### PR TITLE
Add deploy scaffolding

### DIFF
--- a/context.json
+++ b/context.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "project_name": "BajetiBuddy",
-  "last_updated": "2025-06-16T00:00:00Z",
+  "last_updated": "2025-06-17T00:00:00Z",
   "modules": [
     {
       "name": "AuthSystem",
@@ -37,6 +37,11 @@
       "name": "ModelTraining",
       "status": "in_progress",
       "priority": "medium"
+    },
+    {
+      "name": "DeploymentSetup",
+      "status": "planned",
+      "priority": "low"
     }
   ],
   "interfaces": [

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,7 @@
+# TODO: Define production-ready Dockerfile
+FROM node:18-alpine
+WORKDIR /app
+# COPY package.json package-lock.json ./
+# RUN npm install --production
+# COPY . .
+# CMD ["node", "server.js"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,8 @@
+# Deployment Configurations
+
+This directory contains configuration files for deploying BajetiBuddy.
+
+- `Dockerfile`: Container setup for the backend service (placeholder).
+- `github-actions.yml`: Continuous integration pipeline stub.
+
+Additional deployment scripts will be added in future batches.

--- a/deploy/github-actions.yml
+++ b/deploy/github-actions.yml
@@ -1,0 +1,16 @@
+# GitHub Actions CI pipeline (placeholder)
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # TODO: Add build and test steps
+      - run: echo "CI pipeline placeholder"

--- a/log.md
+++ b/log.md
@@ -74,3 +74,10 @@
 - Marked AI-related tasks as in progress in plan.md
 - Added `ModelTraining` module and updated `AIRecommendations` status in context.json
 - Bumped `last_updated` timestamp
+
+## 2025-06-17
+### Added
+- Created `deploy/` directory with placeholder Dockerfile and GitHub Actions workflow
+### Updated
+- Noted new `docker-setup` and `ci-pipeline` tasks in plan.md
+- Added `DeploymentSetup` module to context.json and bumped timestamp

--- a/plan.md
+++ b/plan.md
@@ -19,6 +19,8 @@
 - [ ] `expense-tracker` - Build manual expense entry interface
 - [ ] `budget-calculator` - Core budget calculation logic
 - [ ] `local-storage` - SQLite integration for offline data
+- [ ] `docker-setup` - Create Dockerfile for backend deployment
+- [ ] `ci-pipeline` - Initialize GitHub Actions workflow
 
 ### Phase 2: Payment Integration (M2)  
 - [ ] `mpesa-sdk` - Integrate M-Pesa Daraja API


### PR DESCRIPTION
## Summary
- create `deploy` folder for deployment configurations
- add placeholder Dockerfile and GitHub Actions workflow
- document deploy folder purpose
- update plan and context for deployment tasks
- log the changes

## Testing
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_684b29fdadec8326a151228c6f90eb8e