### PR TITLE
Add Jest tests and Postman config

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/test/**/*.test.ts'],
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['json', 'lcov', 'text', 'clover'],
+};
+
+export default config;

--- a/backend/test/controllers/auth.controller.test.ts
+++ b/backend/test/controllers/auth.controller.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import { AuthController } from '../../src/controllers/auth.controller';
+// TODO: replace with real AuthService implementation
+import { AuthService } from '../../src/services/auth.service';
+
+jest.mock('../../src/services/auth.service');
+const mockAuthService = {
+  login: jest.fn(),
+};
+(AuthService as unknown as jest.Mock).mockImplementation(() => mockAuthService);
+
+describe('AuthController', () => {
+  const app = express();
+  app.use(express.json());
+  const controller = new AuthController();
+  app.post('/auth/login', (req, res, next) => controller.login(req, res, next));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 200 and json on successful login', async () => {
+    mockAuthService.login.mockResolvedValue({ token: 'jwt' });
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'user@test.com', password: 'pass' });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/json/);
+  });
+
+  it('returns 500 when login fails', async () => {
+    mockAuthService.login.mockRejectedValue(new Error('invalid'));
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'bad@test.com', password: 'bad' });
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/backend/test/controllers/budget.controller.test.ts
+++ b/backend/test/controllers/budget.controller.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import express from 'express';
+// TODO: replace with real controller implementation
+import { BudgetController } from '../../src/controllers/budget.controller';
+import { BudgetService } from '../../src/services/budget.service';
+
+jest.mock('../../src/services/budget.service');
+const mockBudgetService = {
+  list: jest.fn(),
+  create: jest.fn(),
+};
+(BudgetService as unknown as jest.Mock).mockImplementation(() => mockBudgetService);
+
+describe('BudgetController', () => {
+  const app = express();
+  app.use(express.json());
+  const controller = new BudgetController();
+  app.get('/budget', (req, res, next) => controller.getBudgets(req, res, next));
+  app.post('/budget', (req, res, next) => controller.createBudget(req, res, next));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /budget returns list', async () => {
+    mockBudgetService.list.mockResolvedValue([{ id: 1 }]);
+
+    const res = await request(app).get('/budget');
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('POST /budget creates budget', async () => {
+    mockBudgetService.create.mockResolvedValue({ id: 1 });
+
+    const res = await request(app)
+      .post('/budget')
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id');
+  });
+});

--- a/backend/test/integration/mpesa.integration.test.ts
+++ b/backend/test/integration/mpesa.integration.test.ts
@@ -1,0 +1,21 @@
+import request from 'supertest';
+import express from 'express';
+
+// TODO: wire up actual Mpesa routes and controllers
+const app = express();
+app.use(express.json());
+
+app.post('/mpesa/stkpush', (req, res) => {
+  // TODO: use MPESA sandbox URL and validate callback HMAC
+  res.status(200).json({ checkoutRequestID: 'placeholder' });
+});
+
+describe('MPESA Integration', () => {
+  it('POST /mpesa/stkpush returns 200', async () => {
+    const res = await request(app)
+      .post('/mpesa/stkpush')
+      .send({ phoneNumber: '254712345678', amount: 10 });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('checkoutRequestID');
+  });
+});

--- a/context.json
+++ b/context.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "project_name": "BajetiBuddy",
-  "last_updated": "2025-06-17T00:00:00Z",
+  "last_updated": "2025-06-18T00:00:00Z",
 
   "modules": [
     {
@@ -43,13 +43,20 @@
       "name": "DeploymentSetup",
       "status": "planned",
       "priority": "low"
-
+    },
+    {
       "name": "MLPipeline",
-      "status": "planned",
-
+      "status": "planned"
+    },
+    {
       "name": "DeploymentPipeline",
       "status": "in_progress",
       "priority": "medium"
+    },
+    {
+      "name": "BackendTests",
+      "status": "in_progress",
+      "priority": "low"
     }
   ],
   "interfaces": [

--- a/docs/test/api/bajetibuddy.postman_tests.yml
+++ b/docs/test/api/bajetibuddy.postman_tests.yml
@@ -1,0 +1,7 @@
+version: '1'
+name: BajetiBuddy API Tests
+scripts:
+  run: >-
+    newman run docs/test/api/bajetibuddy.collection.json \
+      -e docs/test/api/bajetibuddy.environment.json \
+      --bail --reporters cli

--- a/log.md
+++ b/log.md
@@ -130,3 +130,13 @@
 ### Updated
 - Initial deployment pipeline setup scaffolded
 
+
+## 2025-06-18
+### Added
+- Jest configuration file for backend unit tests
+- Sample unit tests for Auth and Budget controllers with Supertest
+- Integration test stub for MPESA endpoint
+- Postman CI config under docs/test/api
+### Updated
+- Added `backend-tests` task in plan.md
+- Added `BackendTests` module in context.json and bumped timestamp

--- a/plan.md
+++ b/plan.md
@@ -23,6 +23,7 @@
 - [ ] `local-storage` - SQLite integration for offline data
 - [ ] `docker-setup` - Create Dockerfile for backend deployment
 - [ ] `ci-pipeline` - Initialize GitHub Actions workflow
+- [ ] `backend-tests` - Add Jest unit and integration tests
 
 ### Phase 2: Payment Integration (M2)  
 - [ ] `mpesa-sdk` - Integrate M-Pesa Daraja API


### PR DESCRIPTION
## Summary
- configure Jest for backend with coverage
- add unit tests for Auth and Budget controllers
- add MPESA integration test stub
- provide Postman Newman CI config
- document backend testing task in plan and context

## Testing
- `npm test` *(fails: package.json missing)*


------
https://chatgpt.com/codex/tasks/task_e_684b3016f4288326bb918eccd096aac4