### PR TITLE
Add env examples and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,13 @@ cd ../backend
 npm install
 npm run dev
 
-Environment variables (create .env files)
-mobile/.env: BACKEND_URL, MPESA_CONSUMER_KEY
-backend/.env: DATABASE_URL, OPENAI_API_KEY, MPESA_SECRET
-text
+Environment variables (copy from `.env.example`)
+mobile/bajeti_buddy/.env: BACKEND_URL, MPESA_CONSUMER_KEY
+backend/.env: PORT, MONGO_URI, OPENAI_API_KEY, MPESA_CONSUMER_KEY
+
+Configuration is loaded automatically:
+- The Node backend reads `backend/.env` via `dotenv` in `src/config/env.ts`.
+- The Flutter app expects a `.env` file under `mobile/bajeti_buddy` at build time.
 
 ### VS Code Configuration
 - Install Flutter and Dart extensions

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+MONGO_URI=mongodb://localhost:27017/bajetibuddy
+OPENAI_API_KEY=your-openai-api-key
+MPESA_CONSUMER_KEY=your-mpesa-consumer-key

--- a/log.md
+++ b/log.md
@@ -154,3 +154,9 @@
 ### Updated
 - Added documentation tasks to plan.md and marked complete
 - Bumped context.json last_updated timestamp
+
+## 2025-06-19
+### Added
+- `.env.example` files under `backend` and `mobile/bajeti_buddy`
+### Updated
+- Documented environment setup and configuration loading in README

--- a/mobile/bajeti_buddy/.env.example
+++ b/mobile/bajeti_buddy/.env.example
@@ -1,0 +1,2 @@
+BACKEND_URL=http://localhost:3000
+MPESA_CONSUMER_KEY=your-mpesa-consumer-key


### PR DESCRIPTION
## Summary
- add `.env.example` in backend and Flutter project
- document how environment variables are loaded
- log addition in `log.md`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b35b3ead48326b6470fb5525390e5